### PR TITLE
added options to allow user to modify extensions.json url

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "Auth0 Extension Update Tester",
   "description": "This extension helps you to test the extension update process",
-  "version": "1.0",
+  "version": "1.1",
   "permissions": [
     "activeTab",
     "webNavigation",
@@ -17,6 +17,7 @@
     "persistent": true
   },
   "manifest_version": 2,
+  "options_page": "options.html",
   "browser_action": {
     "default_title": "This extension helps you to test the extension update process",
     "default_icon": "images/auth0-badge-icon-disabled.png"

--- a/options.html
+++ b/options.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Auth0 Extension Update Tester Options</title>
+</head>
+<body>
+<label>
+    <input type="text" id="extensions" value="https://cdn.auth0.com/extensions/develop/extensions.json" />
+</label>
+<button id="save">Save</button>
+<script src="options.js"></script>
+</body>
+</html>

--- a/options.js
+++ b/options.js
@@ -1,0 +1,17 @@
+function save() {
+  var extensions = document.getElementById('extensions').value;
+  chrome.storage.sync.set({
+    extensions: extensions
+  }, function() {});
+}
+
+function load() {
+  chrome.storage.sync.get({
+    extensions: 'https://cdn.auth0.com/extensions/develop/extensions.json'
+  }, function(items) {
+    document.getElementById('extensions').value = items.extensions;
+  });
+}
+
+document.addEventListener('DOMContentLoaded', load);
+document.getElementById('save').addEventListener('click', save);

--- a/worker.js
+++ b/worker.js
@@ -1,5 +1,5 @@
 var cloudPath = '/extensions/extensions.json';
-var appliancePath = '/configuration/static/extensions.json'
+var appliancePath = '/configuration/static/extensions.json';
 var devUrl = 'https://cdn.auth0.com/extensions/develop/extensions.json';
 var urlFilter = [
   'https://cdn.auth0.com/extensions/extensions.json',
@@ -21,7 +21,7 @@ var rewriteExtensions = function(details) {
 
 var rewriteRequestHeaders = function (details) {
   console.log('Details: ', details);
-  
+
    var headers = details.requestHeaders.filter(function(header) {
       var name = header.name.toLowerCase();
       return false;
@@ -31,7 +31,7 @@ var rewriteRequestHeaders = function (details) {
              name !== 'access-control-request-headers'
              name !== 'dnt';
     });
-  
+
     headers.push({ name: 'Origin', value: 'https://cdn.auth0.com' });
     headers.push({ name: 'Access-Control-Request-Method', value: 'GET' });
     headers.push({ name: 'Access-Control-Request-Headers', value: '' });
@@ -65,6 +65,11 @@ var rewriteResponseHeaders = function (details) {
 
 var enableExtension = function() {
   chrome.storage.sync.set({ extension_test_state: true });
+  chrome.storage.sync.get({
+    extensions: devUrl
+  }, function(items) {
+    devUrl = items.extensions;
+  });
   chrome.browserAction.setIcon({ path: 'images/auth0-badge-icon-enabled.png' });
 
   chrome.webRequest.onBeforeRequest.addListener(rewriteExtensions, { urls: urlFilter }, [ 'blocking' ]);
@@ -87,9 +92,9 @@ var toggleExtensionState = function () {
     data = data || {};
     var wasExtensionEnabled = data.extension_test_state || false;
     var isExtensionEnabled = !wasExtensionEnabled;
-    
+
     // Perform and action on the new state
-    if (isExtensionEnabled) { enableExtension(); } 
+    if (isExtensionEnabled) { enableExtension(); }
     else { disableExtension(); }
   });
 };
@@ -99,9 +104,9 @@ var loadExtensionState = function () {
   chrome.storage.sync.get(stateProperty, function(data) {
     data = data || {};
     var isExtensionEnabled = data.extension_test_state || false;
-    
+
     // Perform and action on the new state
-    if (isExtensionEnabled) { enableExtension(); } 
+    if (isExtensionEnabled) { enableExtension(); }
     else { disableExtension(); }
   });
 };


### PR DESCRIPTION
## ✏️ Changes
  Currently, the URL to dev version of `extensions.json` is hardcoded. If i want to load `extensions.json` from localhost i have to modify and reload chrome extension. With this option i can modify url to `extensions.json` without reloading the extension.