### PR TITLE
override assets requests

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "Auth0 Extension Update Tester",
   "description": "This extension helps you to test the extension update process",
-  "version": "1.1",
+  "version": "1.2",
   "permissions": [
     "activeTab",
     "webNavigation",

--- a/options.html
+++ b/options.html
@@ -5,8 +5,13 @@
     <title>Auth0 Extension Update Tester Options</title>
 </head>
 <body>
-<label>
-    <input type="text" id="extensions" value="https://cdn.auth0.com/extensions/develop/extensions.json" />
+<label>URL to the extensions.json:
+    <input
+            type="text"
+            id="extensions"
+            value="https://cdn.auth0.com/extensions/develop/extensions.json"
+            style="width:400px"
+    />
 </label>
 <button id="save">Save</button>
 <script src="options.js"></script>


### PR DESCRIPTION
## ✏️ Changes
  Now the update tester can override requests to the assets. If enabled, it'll redirect all requests to `https://cdn.auth0.com/extensions/**/*.js(css)` to `https://cdn.auth0.com/extensions/develop/**/*.js(css)`, allowing engineers to test extensions, deployed in development mode. 
  